### PR TITLE
use node for postinstall, compatible with Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "tasks"
   ],
   "scripts": {
-    "postinstall": "script/post-install.js",
+    "postinstall": "node script/post-install.js",
     "test": "grunt test"
   },
   "dependencies": {},


### PR DESCRIPTION
fixes issue "'script' is not recognized as an internal or external command" when installing under Windows